### PR TITLE
Refactor PatchStorage

### DIFF
--- a/examples/step-94/CMakeLists.txt
+++ b/examples/step-94/CMakeLists.txt
@@ -3,7 +3,7 @@
 ##
 
 # Set the name of the project and target:
-set(TARGET "step-98")
+set(TARGET "step-94")
 
 # Declare all source files the target consists of. Here, this is only
 # the one step-X.cc file, but as you expand your project you may wish


### PR DESCRIPTION
Extract RegularPatch and GeneralPatch into RegularVertexPatch and GeneralVertexPatch, updating references and templating by dimension. 